### PR TITLE
Fix for a bug causing an index error in mass_spectrum\calc\PeakPicking.py

### DIFF
--- a/corems/mass_spectrum/calc/PeakPicking.py
+++ b/corems/mass_spectrum/calc/PeakPicking.py
@@ -13,25 +13,25 @@ class PeakPicking:
         max_picking_mz = self.settings.max_picking_mz
         min_picking_mz = self.settings.min_picking_mz
         
-        final =  where(self.mz_exp_profile  > min_picking_mz)[-1][-1]
-        comeco =  where(self.mz_exp_profile  > min_picking_mz)[0][0]
+        minFinal =  where(self.mz_exp_profile  > min_picking_mz)[-1][-1]
+        minComeco =  where(self.mz_exp_profile  > min_picking_mz)[0][0]
 
-        mz_domain_X_low_cutoff, mz_domain_low_Y_cutoff,  = self.mz_exp_profile [comeco:final], self.abundance_profile[comeco:final]
+        mz_domain_X_low_cutoff, mz_domain_low_Y_cutoff,  = self.mz_exp_profile [minComeco:minFinal], self.abundance_profile[minComeco:minFinal]
 
-        final =  where(self.mz_exp_profile < max_picking_mz)[-1][-1]
-        comeco =  where(self.mz_exp_profile < max_picking_mz)[0][0]
+        maxFinal =  where(self.mz_exp_profile < max_picking_mz)[-1][-1]
+        maxComeco =  where(self.mz_exp_profile < max_picking_mz)[0][0]
 
         if self.has_frequency:
             
             if self.freq_exp_profile.any():
 
-                freq_domain_Y_cutoff  = self.freq_exp_profile[comeco:final]
+                freq_domain_low_Y_cutoff  = self.freq_exp_profile[minComeco:minFinal]
 
-                return mz_domain_X_low_cutoff[comeco:final], mz_domain_low_Y_cutoff[comeco:final], freq_domain_Y_cutoff[comeco:final]
+                return mz_domain_X_low_cutoff[maxComeco:maxFinal], mz_domain_low_Y_cutoff[maxComeco:maxFinal], freq_domain_low_Y_cutoff[maxComeco:maxFinal]
 
         else:
 
-            return mz_domain_X_low_cutoff[comeco:final], mz_domain_low_Y_cutoff[comeco:final], None
+            return mz_domain_X_low_cutoff[maxComeco:maxFinal], mz_domain_low_Y_cutoff[maxComeco:maxFinal], None
 
     def do_peak_picking(self):
 

--- a/corems/mass_spectrum/calc/PeakPicking.py
+++ b/corems/mass_spectrum/calc/PeakPicking.py
@@ -13,25 +13,25 @@ class PeakPicking:
         max_picking_mz = self.settings.max_picking_mz
         min_picking_mz = self.settings.min_picking_mz
         
-        minFinal =  where(self.mz_exp_profile  > min_picking_mz)[-1][-1]
-        minComeco =  where(self.mz_exp_profile  > min_picking_mz)[0][0]
+        min_final =  where(self.mz_exp_profile  > min_picking_mz)[-1][-1]
+        min_comeco =  where(self.mz_exp_profile  > min_picking_mz)[0][0]
 
-        mz_domain_X_low_cutoff, mz_domain_low_Y_cutoff,  = self.mz_exp_profile [minComeco:minFinal], self.abundance_profile[minComeco:minFinal]
+        mz_domain_X_low_cutoff, mz_domain_low_Y_cutoff,  = self.mz_exp_profile [min_comeco:min_final], self.abundance_profile[min_comeco:min_final]
 
-        maxFinal =  where(self.mz_exp_profile < max_picking_mz)[-1][-1]
-        maxComeco =  where(self.mz_exp_profile < max_picking_mz)[0][0]
+        max_final =  where(self.mz_exp_profile < max_picking_mz)[-1][-1]
+        max_comeco =  where(self.mz_exp_profile < max_picking_mz)[0][0]
 
         if self.has_frequency:
             
             if self.freq_exp_profile.any():
 
-                freq_domain_low_Y_cutoff  = self.freq_exp_profile[minComeco:minFinal]
+                freq_domain_low_Y_cutoff  = self.freq_exp_profile[min_comeco:min_final]
 
-                return mz_domain_X_low_cutoff[maxComeco:maxFinal], mz_domain_low_Y_cutoff[maxComeco:maxFinal], freq_domain_low_Y_cutoff[maxComeco:maxFinal]
+                return mz_domain_X_low_cutoff[max_comeco:max_final], mz_domain_low_Y_cutoff[max_comeco:max_final], freq_domain_low_Y_cutoff[max_comeco:max_final]
 
         else:
 
-            return mz_domain_X_low_cutoff[maxComeco:maxFinal], mz_domain_low_Y_cutoff[maxComeco:maxFinal], None
+            return mz_domain_X_low_cutoff[max_comeco:max_final], mz_domain_low_Y_cutoff[max_comeco:max_final], None
 
     def do_peak_picking(self):
 


### PR DESCRIPTION
Running this code:

```
from corems.transient.input.brukerSolarix import ReadBrukerSolarix
from corems.encapsulation.factory.parameters import MSParameters
MSParameters.mass_spectrum.threshold_method = 'signal_noise'
MSParameters.mass_spectrum.s2n_threshold = 4
file_path= 'Ezra MS 060532_000005.d srfa iii'
bruker_reader = ReadBrukerSolarix(file_path)
bruker_transient_obj = bruker_reader.get_transient()
mass_spectrum_obj = bruker_transient_obj.get_mass_spectrum(plot_result=False, auto_process=True)
```

gave the following error:
![Screenshot 2021-05-13 163859](https://user-images.githubusercontent.com/32281980/118149766-c5baef80-b409-11eb-966b-77eeab447181.png)

This was due to the list `freq` having a different length to `mz `and `abundance` in the `PeakPicking.py` class. I think this problem is due to the mz cut offs not being equally applied to `self.freq_exp_profile` in  the `cut_mz_domain_peak_picking(self)` function which returns these lists.

I have come up with a possible fix for this by first applying the low mz cut off to `self.freq_exp_profile` to create a new variable `freq_domain_low_Y_cutoff` and then applying the high mz cut off.  This gets rid of the error when running the above code, but I haven't tested the change in any other way. I'm also not 100 % sure about this, so definitely needs reviewing. 