### PR TITLE
Added options for nominal kendrick mass calculation

### DIFF
--- a/corems/encapsulation/factory/processingSetting.py
+++ b/corems/encapsulation/factory/processingSetting.py
@@ -119,6 +119,10 @@ class MassSpectrumSetting:
 class MassSpecPeakSetting:
 
     kendrick_base: Dict = dataclasses.field(default_factory=dict)
+    
+    kendrick_rounding_method: str = 'floor' # 'floor', 'ceil' or 'round' are valid methods for calculating nominal kendrick mass
+    
+    implemented_kendrick_rounding_methods : tuple = ('floor','ceil','round')
 
     # kendrick_base : Dict =  {'C': 1, 'H':2}
 

--- a/corems/ms_peak/calc/MSPeakCalc.py
+++ b/corems/ms_peak/calc/MSPeakCalc.py
@@ -5,8 +5,9 @@ import warnings
 
 
 from scipy.stats import norm, cauchy
-from numpy import linspace, sqrt, log, trapz, pi, log, poly1d, polyfit,flip, square,exp, nan
+from numpy import linspace, sqrt, log, trapz, pi, log, poly1d, polyfit,flip, square,exp, nan, ceil, rint, floor
 from corems.encapsulation.constant import Atoms
+from corems.encapsulation.factory.parameters import MSParameters
 from lmfit import models
 import pyswarm
 
@@ -19,6 +20,7 @@ class MSPeakCalculation(object):
     def _calc_kdm(self, dict_base):
         '''dict_base = {"C": 1, "H": 2}
         '''
+        kendrick_rounding_method = MSParameters.ms_peak.kendrick_rounding_method # rounding method can be one of floor, ceil or round
 
         mass = 0
         for atom in dict_base.keys():
@@ -26,7 +28,20 @@ class MSPeakCalculation(object):
 
         kendrick_mass = (int(mass) / mass) * self.mz_exp
 
-        nominal_km = int(kendrick_mass)
+        if kendrick_rounding_method == 'ceil':
+
+            nominal_km = ceil(kendrick_mass)
+
+        elif kendrick_rounding_method == 'round': 
+
+            nominal_km = rint(kendrick_mass)
+
+        elif kendrick_rounding_method == 'floor':
+
+            nominal_km = floor(kendrick_mass)
+
+        else:
+            raise  Exception("%s method was not implemented, please refer to corems.ms_peak.calc.MSPeakCalc Class" % kendrick_rounding_method)
 
         kmd = (nominal_km - kendrick_mass) 
 


### PR DESCRIPTION
It might be good to support different rounding methods to calculate nominal kendrick mass in kendrick mass defect calculations. 

I noticed that corems uses `int(kendrick_mass)` to calculate nominal kendrick mass, so the kendrick mass is always rounded down to the nearest integer. This isn’t the same nominal kendrick mass calculation as is performed in [Hughey, Christine A., et al. (2001)](https://pubs.acs.org/doi/10.1021/ac010560w), in which the kendrick mass us rounded up to the nearest integer (e.g. for km = 350.9346 351, nkm = 360, kmd = 0.66).  I’ve also seen nominal kendrick mass rounded up or down to nearest integer  (e.g. [Cody, Robert B., and Thierry Fouquet (2018)](https://link.springer.com/article/10.1007/s13361-018-2040-9) ).

The differences aren’t too important for analyzing mass defect plots, but they could become confusing when you are comparing mass defects between studies. 

This pull request adds three new rounding methods, ‘ceil’: nominal km always rounded up to the nearest integer, ‘round’:  nominal km rounded up or down to the nearest integer and ‘floor’: (default) nominal km always rounded down to the nearest integer.

I haven’t added a settings attribute to the ICRMassPeak class so instead MsPeakCalc imports MSSettings to read kendrick_rounding_method. I can imagine it is a bit cleaner to instead use self.settings to read the rounding method, but I am unsure about messing with the classes too much. 

Hopefully this is useful. The changes seem to work in my limited testing but might need some tidying up.

Thanks, 
Ezra
