### PR TITLE
Added mass constraints to molecular search parameters

### DIFF
--- a/corems/encapsulation/factory/processingSetting.py
+++ b/corems/encapsulation/factory/processingSetting.py
@@ -343,6 +343,10 @@ class MolecularFormulaSearchSettings:
     '''query setting'''
     ion_charge: int = -1
 
+    min_mz: float = 100
+
+    max_mz: float = 1200
+
     min_hc_filter: float = 0.3
 
     max_hc_filter: float = 3

--- a/corems/molecular_id/factory/molecularSQL.py
+++ b/corems/molecular_id/factory/molecularSQL.py
@@ -254,6 +254,10 @@ class MolForm_SQL:
                             CarbonHydrogen.c <= molecular_search_settings.usedAtoms.get("C")[1],
                             CarbonHydrogen.h >= molecular_search_settings.usedAtoms.get("H")[0],
                             CarbonHydrogen.h <= molecular_search_settings.usedAtoms.get("H")[1],
+                            and_(
+                                MolecularFormulaLink.mass >= molecular_search_settings.min_mz,
+                                MolecularFormulaLink.mass <= molecular_search_settings.max_mz
+                            )
                         )
                     )
                 )


### PR DESCRIPTION
This pull request allows users to specify minimum and maximum mass values as constraints in molecular formula assignment. 

For example to assign formula based on the following constraint: 150 < m/z < 1000

You can specify :
MSParameters.molecular_search.min_mz = 150
MSParameters.molecular_search.max_mz = 1000

