### PR TITLE
Fix min and max mz filtering in cut_mz_domain_noise

### DIFF
--- a/corems/mass_spectrum/calc/NoiseCalc.py
+++ b/corems/mass_spectrum/calc/NoiseCalc.py
@@ -122,7 +122,7 @@ class NoiseThresholdCalc:
             max_mz_noise = max_mz_whole_ms
         
         #the following indexing relies on mz_exp_profile being ordered high mz to low mz
-        low_mz_index = (where(self.mz_exp_profile >= min_mz_noise)[0][-1])
+        low_mz_index = (where(self.mz_exp_profile >= min_mz_noise)[-1][-1])
         #print(self.mz_exp_profile[low_mz_index])
         #low_mz_index = (argmax(self.mz_exp_profile <= min_mz_noise))
 

--- a/corems/mass_spectrum/calc/NoiseCalc.py
+++ b/corems/mass_spectrum/calc/NoiseCalc.py
@@ -120,20 +120,20 @@ class NoiseThresholdCalc:
 
         if max_mz_noise > max_mz_whole_ms:
             max_mz_noise = max_mz_whole_ms
-
-        #print(min_mz_noise, max_mz_noise)
-        low_mz_index = (where(self.mz_exp_profile >= min_mz_noise)[0][0])
+        
+        #the following indexing relies on mz_exp_profile being ordered high mz to low mz
+        low_mz_index = (where(self.mz_exp_profile >= min_mz_noise)[0][-1])
         #print(self.mz_exp_profile[low_mz_index])
-        # low_mz_index = (argmax(self.mz_exp_profile <= min_mz_noise))
-        
-        high_mz_index = (where(self.mz_exp_profile <= max_mz_noise)[-1][-1])
-        
+        #low_mz_index = (argmax(self.mz_exp_profile <= min_mz_noise))
+
+        high_mz_index = (where(self.mz_exp_profile <= max_mz_noise)[0][0])
+        #print(self.mz_exp_profile[high_mz_index])
         #high_mz_index = (argmax(self.mz_exp_profile <= max_mz_noise))
         
         if high_mz_index > low_mz_index:
             # pyplot.plot(self.mz_exp_profile[low_mz_index:high_mz_index], self.abundance_profile[low_mz_index:high_mz_index])
             # pyplot.show()
-            return self.mz_exp_profile[high_mz_index:low_mz_index], self.abundance_profile[low_mz_index:high_mz_index]
+            return self.mz_exp_profile[low_mz_index:high_mz_index], self.abundance_profile[low_mz_index:high_mz_index]
         else:
             # pyplot.plot(self.mz_exp_profile[high_mz_index:low_mz_index], self.abundance_profile[high_mz_index:low_mz_index])
             # pyplot.show()


### PR DESCRIPTION
I noticed that changing the min_mz_noise and max_mz_noise parameters did not effect the baseline noise calculation when the threshold method was 'signal_noise'. 

This seems to be fixed by changing the indexing in the cut_mz_domain_noise method in the NoiseThresholdCalc class. 
Because mz_exp_profile was ordered from high to low in my tests, the indexing in the following commands needed to be reversed. 

So I changed
 
```
 low_mz_index = (where(self.mz_exp_profile >= min_mz_noise)[0][0])
 high_mz_index = (where(self.mz_exp_profile <= max_mz_noise)[-1][-1])
```

to:

 ```
low_mz_index = (where(self.mz_exp_profile >= min_mz_noise)[-1][-1])
high_mz_index = (where(self.mz_exp_profile <= max_mz_noise)[0][0]) 
```

I saw that there was an if statement at the end of the function which compares the low_mz_index and high_mz_index to determine the order of the slice. This implies that the order of mz_exp_profile is not always fixed, in which case a more flexible solution is required. Happy to implement this if this is the case, otherwise I think the current fix will be fine. 

I also changed the if statement at the end of the function which had the low_mz_index and high_mz_index variables in the wrong order. 

EDIT 07/03/23: Changed the first index to -1 for low_mz_index in case the mz_exp_profile is a 2D array


