### PR TITLE
Adjust thermo reader to comply with pythonnet 3.0 changes

### DIFF
--- a/corems/mass_spectra/input/rawFileReader.py
+++ b/corems/mass_spectra/input/rawFileReader.py
@@ -68,7 +68,7 @@ class ThermoBaseClass():
 
         self.iRawDataPlus = RawFileReaderAdapter.FileFactory(str(file_path))
 
-        self.res = self.iRawDataPlus.SelectInstrument(0, 1)
+        self.res = self.iRawDataPlus.SelectInstrument(Device.MS, 1)
         
         self.file_path = file_location
         self.iFileHeader = FileHeaderReaderFactory.ReadFile(str(file_path))


### PR DESCRIPTION
Pythonnet enforces the use of the enum name and depreciated the legacy behavior of allowing the use of an integer call. This change is a compatibility update only, with no functional changes.