### PR TITLE
option to export all candidate formulas -- issue #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-env/
+cd-tests/
+BATS/
+env*/
 venv/ 
 test_env/ 
 venv310/

--- a/corems/encapsulation/factory/processingSetting.py
+++ b/corems/encapsulation/factory/processingSetting.py
@@ -663,7 +663,7 @@ class MolecularFormulaSearchSettings:
         Tuple of score method that can be implemented. 
         Default is ('S_P_lowest_error', 'N_S_P_lowest_error', 'lowest_error', 'prob_score', 'air_filter_error', 'water_filter_error', 'earth_filter_error').
     score_method : str, optional
-        Score method to use. Default is 'prob_score'. Options are 'S_P_lowest_error', 'N_S_P_lowest_error', 'lowest_error', 'prob_score', 'air_filter_error', 'water_filter_error', 'earth_filter_error'.   
+        Score method to use. Default is 'prob_score'. Options are 'S_P_lowest_error', 'N_S_P_lowest_error', 'lowest_error', 'prob_score', 'air_filter_error', 'water_filter_error', 'earth_filter_error', 'all_candidates'.   
     output_min_score : float, optional
         Minimum score for output. Default is 0.1.
     output_score_method : str, optional
@@ -744,7 +744,7 @@ class MolecularFormulaSearchSettings:
     adduct_atoms_pos: tuple = ('Na', 'K')
 
     score_methods: tuple = ('S_P_lowest_error', 'N_S_P_lowest_error', 'lowest_error', 'prob_score',
-                            'air_filter_error', 'water_filter_error', 'earth_filter_error')
+                            'air_filter_error', 'water_filter_error', 'earth_filter_error', 'all_candidates')
 
     score_method: str = 'prob_score'
 

--- a/corems/mass_spectrum/output/export.py
+++ b/corems/mass_spectrum/output/export.py
@@ -590,18 +590,37 @@ class HighResMassSpecExport(Thread):
                 # print(ms_peak.mz_exp)
 
                 if ms_peak:
+                    
+                    if selected_score_method == 'all_candidates':
+                        
+                        formula_list = ms_peak.best_molecular_formula_candidate 
 
-                    m_formula = ms_peak.best_molecular_formula_candidate
+                        for m_formula in formula_list:
 
-                    if m_formula:
+                            if m_formula:
 
-                        if not m_formula.is_isotopologue:
+                                if not m_formula.is_isotopologue:
 
-                            add_match_dict_data(index, ms_peak, m_formula)
+                                    add_match_dict_data(index, ms_peak, m_formula)
 
-                            for iso_mspeak_index, iso_mf_formula in m_formula.mspeak_mf_isotopologues_indexes:
-                                iso_ms_peak = mass_spectrum[iso_mspeak_index]
-                                add_match_dict_data(iso_mspeak_index, iso_ms_peak, iso_mf_formula)
+                                    for iso_mspeak_index, iso_mf_formula, in m_formula.mspeak_mf_isotopologues_indexes:
+
+                                        iso_ms_peak = mass_spectrum[iso_mspeak_index]
+                                        add_match_dict_data(iso_mspeak_index, iso_ms_peak, iso_mf_formula)
+
+                    else:
+                        
+                        m_formula = ms_peak.best_molecular_formula_candidate
+
+                        if m_formula:
+
+                            if not m_formula.is_isotopologue:
+
+                                add_match_dict_data(index, ms_peak, m_formula)
+
+                                for iso_mspeak_index, iso_mf_formula in m_formula.mspeak_mf_isotopologues_indexes:
+                                    iso_ms_peak = mass_spectrum[iso_mspeak_index]
+                                    add_match_dict_data(iso_mspeak_index, iso_ms_peak, iso_mf_formula)
                 else:
 
                     if include_no_match and no_match_inline:

--- a/corems/ms_peak/factory/MSPeakClasses.py
+++ b/corems/ms_peak/factory/MSPeakClasses.py
@@ -392,6 +392,10 @@ class _MSPeak(MSPeakCalculation):
 
         elif self._ms_parent.molecular_search_settings.score_method == "prob_score":
             return self.molecular_formula_highest_prob_score()
+        
+        elif self._ms_parent.molecular_search_settings.score_method == "all_candidates":
+            return self.molecular_formulas
+        
         else:
             raise TypeError(
                 "Unknown score method selected: % s, \


### PR DESCRIPTION
These changes allow for the option to export all candidate formulas for an m/z peak. This feature is helpful for gap-filling across large sample sets. 