### PR TITLE
Fix duplicated variable in baseline noise check

### DIFF
--- a/corems/mass_spectrum/factory/MassSpectrumClasses.py
+++ b/corems/mass_spectrum/factory/MassSpectrumClasses.py
@@ -1091,7 +1091,7 @@ class MassSpecBase(MassSpecCalc, KendrickGrouping):
         """
         import matplotlib.pyplot as plt
 
-        if self.baseline_noise_std and self.baseline_noise_std:
+        if self.baseline_noise is not None and self.baseline_noise_std is not None:
             # x = (self.mz_exp_profile.min(), self.mz_exp_profile.max())
             baseline = (self.baseline_noise, self.baseline_noise)
 


### PR DESCRIPTION
## Summary
- `MassSpecBase.plot_mz_domain_profile()` (line 1094) checks `self.baseline_noise_std` twice instead of checking `self.baseline_noise` and `self.baseline_noise_std`
- Changed from truthiness check to `is not None` so valid `0.0` values are not incorrectly treated as missing

## Before
```python
if self.baseline_noise_std and self.baseline_noise_std:
```

## After
```python
if self.baseline_noise is not None and self.baseline_noise_std is not None:
```

## Test plan
- Verified the fix matches the intended logic by inspecting surrounding code (line 1096 uses `self.baseline_noise`)
- One-line change, no behavioral impact except correcting the None/zero handling