### PR TITLE
Fix divide-by-zero in aromaticity index calculation

### DIFF
--- a/corems/molecular_formula/calc/MolecularFormulaCalc.py
+++ b/corems/molecular_formula/calc/MolecularFormulaCalc.py
@@ -560,7 +560,7 @@ class MolecularFormulaCalc:
         )
         ai_d = ai_es["C"] - (0.5 * ai_es["O"]) - ai_es["N"] - ai_es["S"]
 
-        ai = ai_n / ai_d
+        ai = ai_n / ai_d if ai_d != 0 else 0
 
         if ai < 0:
             ai = 0
@@ -601,7 +601,7 @@ class MolecularFormulaCalc:
                 )
         ai_d = ai_es["C"] - (ai_es["O"]) - ai_es["N"] - ai_es["S"]
 
-        ai = ai_n / ai_d
+        ai = ai_n / ai_d if ai_d != 0 else 0
 
         if ai < 0:
             ai = 0

--- a/corems/molecular_formula/calc/MolecularFormulaCalc.py
+++ b/corems/molecular_formula/calc/MolecularFormulaCalc.py
@@ -560,12 +560,12 @@ class MolecularFormulaCalc:
         )
         ai_d = ai_es["C"] - (0.5 * ai_es["O"]) - ai_es["N"] - ai_es["S"]
 
-        ai = ai_n / ai_d if ai_d != 0 else 0
-
-        if ai < 0:
+        if ai_n <= 0 or ai_d <= 0:
             ai = 0
-        if ai > 1:
-            ai = 1
+        else:
+            ai = ai_n / ai_d
+            if ai > 1:
+                ai = 1
 
         return ai
 
@@ -601,12 +601,12 @@ class MolecularFormulaCalc:
                 )
         ai_d = ai_es["C"] - (ai_es["O"]) - ai_es["N"] - ai_es["S"]
 
-        ai = ai_n / ai_d if ai_d != 0 else 0
-
-        if ai < 0:
+        if ai_n <= 0 or ai_d <= 0:
             ai = 0
-        if ai > 1:
-            ai = 1
+        else:
+            ai = ai_n / ai_d
+            if ai > 1:
+                ai = 1
 
         return ai
 


### PR DESCRIPTION
## Summary
- `_calc_ai()` and `_calc_ai_mod()` in `MolecularFormulaCalc` divide `ai_n / ai_d` without guarding against `ai_d == 0`
- This raises `ZeroDivisionError` for molecular formulas where `C - 0.5*O - N - S` (or `C - O - N - S` for modified AI) equals zero
- Returns 0 when denominator is zero, consistent with the existing clamping to `[0, 1]`

## Before
```python
ai = ai_n / ai_d
```

## After
```python
ai = ai_n / ai_d if ai_d != 0 else 0
```

Applied to both `_calc_ai()` (line 563) and `_calc_ai_mod()` (line 604).

## References
- Koch and Dittmar, 2006: https://doi.org/10.1002/rcm.2386
- Correction: https://doi.org/10.1002/rcm.7433

## Test plan
- Verified both methods have the same pattern and same fix
- A denominator of zero means no aromatic carbon skeleton is possible, so AI = 0 is the correct semantic value