### PR TITLE
Fix MassListBaseClass ignoring user-configured DataInputSetting

### DIFF
--- a/corems/mass_spectrum/input/baseClass.py
+++ b/corems/mass_spectrum/input/baseClass.py
@@ -12,8 +12,7 @@ from pandas.core.frame import DataFrame
 from s3path import S3Path
 
 from corems.encapsulation.constant import Labels
-from corems.encapsulation.factory.parameters import default_parameters
-from corems.encapsulation.factory.processingSetting import DataInputSetting
+from corems.encapsulation.factory.parameters import MSParameters, default_parameters
 from corems.encapsulation.input.parameter_from_json import (
     load_and_set_parameters_class,
     load_and_set_parameters_ms,
@@ -112,7 +111,7 @@ class MassListBaseClass:
 
         self.sample_name = sample_name
 
-        self._parameters = deepcopy(DataInputSetting())
+        self._parameters = deepcopy(MSParameters.data_input)
 
     @property
     def parameters(self):


### PR DESCRIPTION
## Summary
- `MassListBaseClass.__init__` uses `deepcopy(DataInputSetting())` which always creates a fresh default instance
- This ignores any user customizations set on `MSParameters.data_input` (e.g. custom `header_translate` mappings)
- Changed to `deepcopy(MSParameters.data_input)` to respect user-configured parameters, consistent with how other parameter classes are used throughout CoreMS

## Before
```python
from corems.encapsulation.factory.processingSetting import DataInputSetting
...
self._parameters = deepcopy(DataInputSetting())
```

## After
```python
from corems.encapsulation.factory.parameters import MSParameters, default_parameters
...
self._parameters = deepcopy(MSParameters.data_input)
```

## Test plan
- Verified `MSParameters.data_input` is the canonical source used elsewhere in the codebase (e.g. `parameters.py` line 77, 85, 91)
- `DataInputSetting` import is no longer needed (remaining references are in docstrings and parameter names only)