### PR TITLE
Fix Kendrick base consistency between MSPeak and MolecularFormula

### DIFF
--- a/corems/molecular_formula/factory/MolecularFormulaFactory.py
+++ b/corems/molecular_formula/factory/MolecularFormulaFactory.py
@@ -136,7 +136,9 @@ class MolecularFormulaBase(MolecularFormulaCalc):
                 self._mspeak_parent._ms_parent.mspeaks_settings.kendrick_base
             )
         else:
-            kendrick_dict_base = {"C": 1, "H": 2}
+            from corems.encapsulation.factory.parameters import MSParameters
+
+            kendrick_dict_base = MSParameters.ms_peak.kendrick_base
         self._kmd, self._kendrick_mass, self._nominal_km = self._calc_kmd(
             kendrick_dict_base
         )

--- a/corems/ms_peak/factory/MSPeakClasses.py
+++ b/corems/ms_peak/factory/MSPeakClasses.py
@@ -139,6 +139,10 @@ class _MSPeak(MSPeakCalculation):
             kendrick_dict_base
         )
 
+        # Also update all associated molecular formulas
+        for mf in self.molecular_formulas:
+            mf._kmd, mf._kendrick_mass, mf._nominal_km = mf._calc_kmd(kendrick_dict_base)
+
     def add_molecular_formula(self, molecular_formula_obj):
         """Adds a molecular formula to the peak.
 


### PR DESCRIPTION
## Summary

Two related fixes for Kendrick base handling:

1. **Inconsistent default in MolecularFormulaBase**: When a molecular formula has no parent peak, `__init__` used a hardcoded `{"C": 1, "H": 2}` fallback instead of reading from `MSParameters.ms_peak.kendrick_base`. This meant user-configured Kendrick bases were ignored for orphan formulas.

2. **Stale formula KMD after base change**: `MSPeak.change_kendrick_base()` recalculated KMD for the peak but not for its associated molecular formulas. When `change_kendrick_base_all_mspeaks()` is called after formula assignment (as in `priorityAssignment.py` and `findOxygenPeaks.py`), formulas retained stale KMD values.

## Changes

**MolecularFormulaFactory.py**
```python
# Before: hardcoded fallback
kendrick_dict_base = {"C": 1, "H": 2}

# After: reads from MSParameters
from corems.encapsulation.factory.parameters import MSParameters
kendrick_dict_base = MSParameters.ms_peak.kendrick_base
```

**MSPeakClasses.py** — added to `change_kendrick_base()`:
```python
# Also update all associated molecular formulas
for mf in self.molecular_formulas:
    mf._kmd, mf._kendrick_mass, mf._nominal_km = mf._calc_kmd(kendrick_dict_base)
```

## Test plan
- Verified `change_kendrick_base_all_mspeaks()` is the canonical entry point (called in `priorityAssignment.py:273` and `findOxygenPeaks.py:92`)
- That method iterates all peaks calling `mspeak.change_kendrick_base()`, which now also updates formulas
- Existing test in `tests/test_mspeak.py:32` exercises `change_kendrick_base`