### PR TITLE
Fix COREMS_DATABASE_URL env var not overriding hardcoded default

### DIFF
--- a/corems/encapsulation/factory/processingSetting.py
+++ b/corems/encapsulation/factory/processingSetting.py
@@ -977,8 +977,9 @@ class MolecularFormulaSearchSettings:
 
     min_peaks_per_class: int = 15
 
-    url_database: str = (
-        "postgresql+psycopg2://coremsappdb:coremsapppnnl@localhost:5432/coremsapp"
+    url_database: str = os.getenv(
+        "COREMS_DATABASE_URL",
+        "postgresql+psycopg2://coremsappdb:coremsapppnnl@localhost:5432/coremsapp",
     )
 
     db_jobs: int = 3


### PR DESCRIPTION
## Summary

- The `MolecularFormulaSearchSettings.url_database` field has a hardcoded default pointing to `localhost:5432`
- The `__post_init__` method checks `COREMS_DATABASE_URL` only when `url_database` is empty, but the hardcoded default means it's never empty — so the env var from `.env` (which points to the `molformdb` compose service) is silently ignored
- Moves the `os.getenv("COREMS_DATABASE_URL", ...)` call to the field default so it's respected at initialization time, while preserving the `localhost` fallback for non-compose setups

## Test plan

- [ ] Verify `SearchMolecularFormulas` connects to the `molformdb` service when using `docker-compose.yml` with the provided `.env`
- [ ] Verify `localhost` fallback still works when `COREMS_DATABASE_URL` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)